### PR TITLE
Fix unified CIS checker command structure

### DIFF
--- a/.github/workflows/deploy-test-infrastructure.yml
+++ b/.github/workflows/deploy-test-infrastructure.yml
@@ -213,7 +213,7 @@ jobs:
           # Run unified checks if available
           if [ -f "unified_cis_checker.py" ]; then
             echo "### Unified CIS Compliance Check"
-            python3 unified_cis_checker.py --region $AWS_DEFAULT_REGION check --format json --output ../test_results_unified.json
+            python3 unified_cis_checker.py aws check --region $AWS_DEFAULT_REGION --format json --output ../test_results_unified.json
           fi
           
           echo "All compliance tests completed"

--- a/.github/workflows/deploy-test-infrastructure.yml
+++ b/.github/workflows/deploy-test-infrastructure.yml
@@ -213,7 +213,7 @@ jobs:
           # Run unified checks if available
           if [ -f "unified_cis_checker.py" ]; then
             echo "### Unified CIS Compliance Check"
-            python3 unified_cis_checker.py aws check --region $AWS_DEFAULT_REGION --format json --output ../test_results_unified.json
+            python3 unified_cis_checker.py --region $AWS_DEFAULT_REGION --format json --output ../test_results_unified.json aws check
           fi
           
           echo "All compliance tests completed"


### PR DESCRIPTION
- Added required 'aws' platform argument before 'check' command
- Unified CIS checker expects: platform command --options
- Now uses correct syntax: aws check --region --format --output