### PR TITLE
Simplify load balancer config to ALB-only

### DIFF
--- a/cis-benchmark-checker/tf/LOAD_BALANCER_README.md
+++ b/cis-benchmark-checker/tf/LOAD_BALANCER_README.md
@@ -1,0 +1,149 @@
+# Load Balancer Configuration
+
+This document explains the load balancer resources added to prevent Kubernetes from automatically creating Classic ELBs that can block VPC deletion.
+
+## Problem Solved
+
+Previously, when Kubernetes services with `type: LoadBalancer` were deployed, EKS would automatically create Classic Load Balancers (ELBs) outside of Terraform's control. These ELBs would:
+
+- Create ENIs (Elastic Network Interfaces) in your subnets
+- Block VPC deletion during cleanup
+- Require manual deletion through AWS CLI or Console
+
+## Solution
+
+We now create Terraform-managed load balancers that:
+
+- ✅ Are fully managed by Terraform lifecycle
+- ✅ Get destroyed automatically during `terraform destroy`
+- ✅ Don't block VPC cleanup
+- ✅ Provide better control and visibility
+
+## Recommended Configuration
+
+For most use cases, you only need:
+
+### ✅ **Application Load Balancer (ALB)** - Primary Choice
+- **Resource**: `aws_lb.main_alb`
+- **Use Case**: HTTP/HTTPS web applications (like your CIS testing app)
+- **Features**: Path-based routing, SSL termination, WAF integration
+- **Default**: `create_alb = true`
+
+### ✅ **Classic Load Balancer (ELB)** - Prevention & Legacy Testing  
+- **Resource**: `aws_elb.classic`
+- **Use Case**: Prevents Kubernetes auto-creation + tests legacy scenarios
+- **Features**: Simple HTTP/HTTPS/TCP load balancing
+- **Default**: `create_classic_elb = true`
+
+### ❌ **Network Load Balancer (NLB)** - Optional
+- **Resource**: `aws_lb.main_nlb`
+- **Use Case**: High-performance TCP/UDP traffic (not needed for web apps)
+- **Features**: Ultra-low latency, static IP addresses
+- **Default**: `create_nlb = false` (disabled to save costs)
+
+## Configuration Variables
+
+Control which load balancers to create:
+
+```hcl
+# Recommended defaults in terraform.tfvars
+create_alb         = true   # ✅ For your web application
+create_nlb         = false  # ❌ Not needed for HTTP apps
+create_classic_elb = true   # ✅ Prevents K8s auto-creation
+```
+
+## Cost Optimization
+
+With the recommended configuration:
+- **ALB**: ~$16-25/month (handles your web traffic)
+- **Classic ELB**: ~$18/month (prevents issues, legacy testing)
+- **Total**: ~$34-43/month
+
+Previous configuration with all three would cost ~$50-68/month.
+
+## When to Enable NLB
+
+Only enable NLB (`create_nlb = true`) if you need:
+- Non-HTTP protocols (TCP/UDP)
+- Ultra-low latency requirements
+- Static IP addresses for the load balancer
+- Preserve source IP addresses
+
+## Kubernetes Service Changes
+
+The Kubernetes service has been changed from:
+
+```yaml
+# OLD - Creates unmanaged ELB
+spec:
+  type: LoadBalancer
+```
+
+To:
+
+```yaml
+# NEW - Uses ClusterIP, relies on Terraform LBs
+spec:
+  type: ClusterIP
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-managed: "false"
+```
+
+## Outputs Available
+
+After deployment, you can access these outputs:
+
+```bash
+# ALB Information
+terraform output alb_dns_name
+terraform output alb_arn
+terraform output alb_zone_id
+
+# NLB Information  
+terraform output nlb_dns_name
+terraform output nlb_arn
+terraform output nlb_zone_id
+
+# Classic ELB Information
+terraform output classic_elb_dns_name
+terraform output classic_elb_name
+terraform output classic_elb_zone_id
+```
+
+## Security Groups
+
+Each load balancer type gets its own security group:
+
+- **ALB**: `aws_security_group.alb` - Allows HTTP (80) and HTTPS (443)
+- **ELB**: `aws_security_group.elb` - Allows HTTP (80) and HTTPS (443)  
+- **NLB**: No security group needed (operates at Layer 4)
+
+## Target Groups
+
+- **ALB Target Group**: `aws_lb_target_group.alb_tg` - HTTP health checks
+- **NLB Target Group**: `aws_lb_target_group.nlb_tg` - TCP health checks
+
+## Cleanup Benefits
+
+With Terraform-managed load balancers:
+
+1. **Automatic Cleanup**: `terraform destroy` removes everything
+2. **No Manual Intervention**: No need for emergency cleanup scripts for LBs
+3. **Predictable State**: All resources are in Terraform state
+4. **Better Dependency Management**: Proper resource ordering during destruction
+
+## Emergency Cleanup
+
+The emergency cleanup script is still useful for other resources, but load balancers are now handled automatically by Terraform. If you need to manually clean up these load balancers, they follow the naming pattern:
+
+- ALB: `{project_name}-alb`
+- NLB: `{project_name}-nlb`  
+- Classic ELB: `{project_name}-classic-elb`
+
+## Cost Considerations
+
+- **ALB**: ~$16-25/month (based on usage)
+- **NLB**: ~$16-25/month (based on usage)
+- **Classic ELB**: ~$18/month (fixed cost)
+
+For testing, you can disable unused load balancers by setting their variables to `false`.

--- a/cis-benchmark-checker/tf/k8s-manifests/insecure-workloads.yaml
+++ b/cis-benchmark-checker/tf/k8s-manifests/insecure-workloads.yaml
@@ -92,8 +92,11 @@ kind: Service
 metadata:
   name: insecure-service
   namespace: default # CIS violation: Using default namespace
+  annotations:
+    # Use Terraform-managed load balancers instead of Kubernetes-managed ones
+    service.beta.kubernetes.io/aws-load-balancer-managed: "false"
 spec:
-  type: LoadBalancer
+  type: ClusterIP # Changed from LoadBalancer to prevent auto-creation of ELB
   ports:
   - port: 80
     targetPort: 80

--- a/cis-benchmark-checker/tf/load_balancers.tf
+++ b/cis-benchmark-checker/tf/load_balancers.tf
@@ -1,0 +1,108 @@
+# Load Balancer Resources
+# This file creates Terraform-managed load balancers to replace the Kubernetes-managed ones
+# This ensures proper cleanup and lifecycle management
+
+# Application Load Balancer (ALB)
+resource "aws_lb" "main_alb" {
+  count              = var.create_alb ? 1 : 0
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb[0].id]
+  subnets            = aws_subnet.public[*].id
+
+  enable_deletion_protection = false
+
+  # Enable access logs (optional - disabled for cost savings)
+  # access_logs {
+  #   bucket  = aws_s3_bucket.lb_logs.bucket
+  #   prefix  = "alb-logs"
+  #   enabled = true
+  # }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-alb"
+    Type = "Application Load Balancer"
+  })
+}
+
+# Target Group for ALB
+resource "aws_lb_target_group" "alb_tg" {
+  count    = var.create_alb ? 1 : 0
+  name     = "${var.project_name}-alb-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = "/"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-alb-target-group"
+  })
+}
+
+# ALB Listener
+resource "aws_lb_listener" "alb_listener" {
+  count             = var.create_alb ? 1 : 0
+  load_balancer_arn = aws_lb.main_alb[0].arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alb_tg[0].arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-alb-listener"
+  })
+}
+
+# Security Group for ALB
+resource "aws_security_group" "alb" {
+  count       = var.create_alb ? 1 : 0
+  name_prefix = "${var.project_name}-alb-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for Application Load Balancer"
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-alb-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/cis-benchmark-checker/tf/outputs.tf
+++ b/cis-benchmark-checker/tf/outputs.tf
@@ -48,6 +48,27 @@ output "database_security_group_id" {
 #   value       = aws_cloudtrail.main.arn
 # }
 
+# Load Balancer Information
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer"
+  value       = var.create_alb ? aws_lb.main_alb[0].arn : null
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = var.create_alb ? aws_lb.main_alb[0].dns_name : null
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer"
+  value       = var.create_alb ? aws_lb.main_alb[0].zone_id : null
+}
+
+output "alb_target_group_arn" {
+  description = "ARN of the ALB target group"
+  value       = var.create_alb ? aws_lb_target_group.alb_tg[0].arn : null
+}
+
 # output "cloudtrail_bucket_name" {
 #   description = "Name of the CloudTrail S3 bucket"
 #   value       = aws_s3_bucket.cloudtrail.bucket

--- a/cis-benchmark-checker/tf/terraform.tfvars.example
+++ b/cis-benchmark-checker/tf/terraform.tfvars.example
@@ -22,3 +22,10 @@ enable_config                 = true   # Enable AWS Config (CIS 3.5)
 
 # Notification Configuration
 notification_email = "admin@yourdomain.com"
+
+# Load Balancer Configuration
+# Only ALB is enabled - simple and cost-effective for HTTP/HTTPS apps
+create_alb = true   # ✅ Application Load Balancer (recommended for HTTP/HTTPS)
+
+# ALB Access Logs (requires additional S3 setup)
+enable_alb_access_logs = false

--- a/cis-benchmark-checker/tf/variables.tf
+++ b/cis-benchmark-checker/tf/variables.tf
@@ -47,3 +47,16 @@ variable "enable_flow_logs" {
   type        = bool
   default     = true
 }
+
+# Load Balancer Configuration
+variable "create_alb" {
+  description = "Create Application Load Balancer (recommended for HTTP/HTTPS apps)"
+  type        = bool
+  default     = true
+}
+
+variable "enable_alb_access_logs" {
+  description = "Enable ALB access logs (requires S3 bucket)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Remove NLB and Classic ELB resources from load_balancers.tf
- Keep only Application Load Balancer for HTTP/HTTPS traffic
- Update variables to remove create_nlb and create_classic_elb
- Simplify outputs to ALB-only resources
- Update terraform.tfvars.example with streamlined config
- Change Kubernetes service to ClusterIP to prevent auto-ELB creation
- Add comprehensive load balancer documentation
