### PR TITLE
🔧 Fix Terraform validation errors for Azure Sentinel deployment

### DIFF
--- a/sentinel-kql-queries/terraform/compute.tf
+++ b/sentinel-kql-queries/terraform/compute.tf
@@ -2,6 +2,7 @@
 resource "azurerm_windows_virtual_machine" "test" {
   count               = var.create_test_vms ? 1 : 0
   name                = "${local.resource_prefix}-testvm"
+  computer_name       = "testvm-${random_string.suffix.result}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   size                = "Standard_B2s"
@@ -65,13 +66,7 @@ resource "azurerm_dev_test_global_vm_shutdown_schedule" "test" {
   tags = local.common_tags
 }
 
-# Security Center Auto Provisioning
-resource "azurerm_security_center_auto_provisioning" "main" {
-  count          = var.enable_defender ? 1 : 0
-  auto_provision = "On"
-}
-
-# Security Center Workspace
+# Security Center Workspace (Auto provisioning is deprecated)
 resource "azurerm_security_center_workspace" "main" {
   count        = var.enable_defender ? 1 : 0
   scope        = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
@@ -81,7 +76,7 @@ resource "azurerm_security_center_workspace" "main" {
 # Key Vault for secrets testing
 resource "azurerm_key_vault" "main" {
   count                       = var.enable_key_vault ? 1 : 0
-  name                        = "${local.resource_prefix}-kv-${random_string.suffix.result}"
+  name                        = "kv-${substr(replace(local.resource_prefix, "-", ""), 0, 11)}-${random_string.suffix.result}"
   location                    = azurerm_resource_group.main.location
   resource_group_name         = azurerm_resource_group.main.name
   enabled_for_disk_encryption = true

--- a/sentinel-kql-queries/terraform/log-analytics.tf
+++ b/sentinel-kql-queries/terraform/log-analytics.tf
@@ -27,7 +27,7 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "main" {
 
 # Storage Account for logs and diagnostics
 resource "azurerm_storage_account" "logs" {
-  name                     = "${replace(local.resource_prefix, "-", "")}logs${random_string.suffix.result}"
+  name                     = "log${substr(replace(local.resource_prefix, "-", ""), 0, 11)}${random_string.suffix.result}"
   resource_group_name      = azurerm_resource_group.main.name
   location                 = azurerm_resource_group.main.location
   account_tier             = "Standard"

--- a/sentinel-kql-queries/terraform/sentinel.tf
+++ b/sentinel-kql-queries/terraform/sentinel.tf
@@ -5,6 +5,7 @@ resource "azurerm_sentinel_data_connector_azure_active_directory" "main" {
   count                      = var.enable_sentinel && var.enable_data_connectors ? 1 : 0
   name                       = "AzureActiveDirectory"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
 }
 
 # Azure Security Center Data Connector
@@ -12,6 +13,7 @@ resource "azurerm_sentinel_data_connector_azure_security_center" "main" {
   count                      = var.enable_sentinel && var.enable_data_connectors ? 1 : 0
   name                       = "AzureSecurityCenter"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
 }
 
 # Office 365 Data Connector
@@ -19,6 +21,7 @@ resource "azurerm_sentinel_data_connector_office_365" "main" {
   count                      = var.enable_sentinel && var.enable_data_connectors ? 1 : 0
   name                       = "Office365"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
 
   exchange_enabled   = true
   sharepoint_enabled = true
@@ -59,6 +62,7 @@ resource "azurerm_sentinel_alert_rule_scheduled" "high_risk_ip" {
   count                      = var.enable_sentinel ? 1 : 0
   name                       = "High-Risk IP Activity"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
   display_name               = "Activity from High-Risk IP Addresses"
 
   severity = "Medium"
@@ -91,6 +95,7 @@ resource "azurerm_sentinel_alert_rule_scheduled" "keyvault_anomalies" {
   count                      = var.enable_sentinel && var.enable_key_vault ? 1 : 0
   name                       = "Key Vault Access Anomalies"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
   display_name               = "Unusual Key Vault Access Patterns"
 
   severity = "Medium"
@@ -120,6 +125,7 @@ resource "azurerm_sentinel_watchlist" "known_good_ips" {
   count                      = var.enable_sentinel ? 1 : 0
   name                       = "KnownGoodIPs"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.main]
   display_name               = "Known Good IP Addresses"
   description                = "List of trusted IP addresses for exclusion from alerts"
 


### PR DESCRIPTION
- Fix Windows VM computer_name length issue (max 15 chars)
- Remove deprecated azurerm_security_center_auto_provisioning resource
- Fix Key Vault naming convention (3-24 chars, alphanumeric + dashes)
- Fix storage account naming (24 char limit, lowercase alphanumeric only)
- Add proper Sentinel workspace onboarding dependencies
- Add depends_on clauses to all Sentinel resources for proper ordering