### PR TITLE
🔧 Fix deployment errors from first GitHub Actions run

### DIFF
--- a/sentinel-kql-queries/terraform/AZURE_AUTHENTICATION_SETUP.md
+++ b/sentinel-kql-queries/terraform/AZURE_AUTHENTICATION_SETUP.md
@@ -114,6 +114,8 @@ chmod +x setup-github-actions.sh
 ./setup-github-actions.sh
 ```
 
+⚠️ **Note:** Some Sentinel data connectors require additional permissions beyond Contributor role (e.g., Global Admin for Azure AD connector). These are disabled by default but can be enabled manually in the Azure portal after deployment.
+
 This script will automatically handle steps 4-6. **Skip to Step 7 if using this option.**
 
 #### **Option B: Manual Creation**

--- a/sentinel-kql-queries/terraform/log-analytics.tf
+++ b/sentinel-kql-queries/terraform/log-analytics.tf
@@ -40,12 +40,13 @@ resource "azurerm_storage_account" "logs" {
   tags = local.common_tags
 }
 
-# Enable Advanced Threat Protection for Storage
-resource "azurerm_advanced_threat_protection" "storage" {
-  count              = var.enable_storage_threats ? 1 : 0
-  target_resource_id = azurerm_storage_account.logs.id
-  enabled            = true
-}
+# Note: Advanced Threat Protection for Storage is deprecated
+# Use Microsoft Defender for Storage at subscription level instead
+# resource "azurerm_advanced_threat_protection" "storage" {
+#   count              = var.enable_storage_threats ? 1 : 0
+#   target_resource_id = azurerm_storage_account.logs.id
+#   enabled            = true
+# }
 
 # Network Security Group with intentional misconfigurations for testing
 resource "azurerm_network_security_group" "test" {


### PR DESCRIPTION
- Remove deprecated Advanced Threat Protection resource (classic plan discontinued)
- Disable Azure AD and Office 365 data connectors (require admin permissions)
- Fix Key Vault alert rule query to use AzureDiagnostics instead of KeyVaultDiagnostics table